### PR TITLE
updating sqs iam policy to include get attributes for use with lambda

### DIFF
--- a/src/iam.tf
+++ b/src/iam.tf
@@ -1,12 +1,12 @@
 locals {
   _subscribe_statement = [{
-    Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage"]
+    Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
     Effect   = "Allow"
     Resource = aws_sqs_queue.main.arn
   }]
 
   _dlq_statement = [{
-    Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage"]
+    Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
     Effect   = "Allow"
     Resource = aws_sqs_queue.dlq.arn
   }]


### PR DESCRIPTION
Lambda needs getQueueAttributes in order to subscribe to SQS.